### PR TITLE
fix: resolve undefined array key warning on defaultvalue assignment

### DIFF
--- a/admin/setup.php
+++ b/admin/setup.php
@@ -86,7 +86,9 @@ $arrayofparameters = array(
 $error = 0;
 $setupnotempty = 0;
 $defaultvalue = '';
-$defaultvalue = $arrayofparameters[$var]['default'];
+if (!empty($var) && isset($arrayofparameters[$var]['default'])) {
+	$defaultvalue = $arrayofparameters[$var]['default'];
+}
 /*
  * Actions
  */


### PR DESCRIPTION
Fixes a PHP warning where an undefined array key and null offset are accessed in setup.php when \ is not defined.